### PR TITLE
Added port option to onvif

### DIFF
--- a/example_control_onvif.py
+++ b/example_control_onvif.py
@@ -5,6 +5,7 @@ from sensecam_control import onvif_control
 
 
 ip = '000.000.000.000'
+port = 80
 login = 'login'
 password = 'password'
 
@@ -66,7 +67,7 @@ def capture(ip_camera):
         event_keyboard(cv2.waitKey(1) & 0xff)
 
 
-X = onvif_control.CameraControl(ip, login, password)
+X = onvif_control.CameraControl(ip, port, login, password)
 X.camera_start()
 
 t = threading.Thread(target=capture, args=(ip,))

--- a/sensecam_control/onvif_config.py
+++ b/sensecam_control/onvif_config.py
@@ -14,8 +14,9 @@ class CameraConfiguration:
     Module for configuration cameras AXIS using Onvif
     """
 
-    def __init__(self, ip, user, password):
+    def __init__(self, ip, port, user, password):
         self.__cam_ip = ip
+        self.__cam_port = port
         self.__cam_user = user
         self.__cam_password = password
 
@@ -27,7 +28,7 @@ class CameraConfiguration:
         Returns:
             Return the ptz service object and media service object
         """
-        mycam = ONVIFCamera(self.__cam_ip, 80, self.__cam_user, self.__cam_password)
+        mycam = ONVIFCamera(self.__cam_ip, self.__cam_port, self.__cam_user, self.__cam_password)
         logging.info('Create media service object')
         media = mycam.create_media_service()
         logging.info('Get target profile')

--- a/sensecam_control/onvif_control.py
+++ b/sensecam_control/onvif_control.py
@@ -13,8 +13,9 @@ class CameraControl:
     Module for control cameras AXIS using Onvif
     """
 
-    def __init__(self, ip, user, password):
+    def __init__(self, ip, port, user, password):
         self.__cam_ip = ip
+        self.__cam_port = port
         self.__cam_user = user
         self.__cam_password = password
 
@@ -33,7 +34,7 @@ class CameraControl:
         Returns:
             Return the ptz service object and media service object
         """
-        mycam = ONVIFCamera(self.__cam_ip, 80, self.__cam_user, self.__cam_password)
+        mycam = ONVIFCamera(self.__cam_ip, self.__cam_port, self.__cam_user, self.__cam_password)
         logging.info('Create media service object')
         media = mycam.create_media_service()
         logging.info('Create ptz service object')


### PR DESCRIPTION
Added the option to specify the port for a ONVIFCamera. 

I added this, because not every camera that uses ONVIF works via port 80. My camera works on port 8899. With this change it makes it possible to use other ports than only port 80.